### PR TITLE
fix(load): adicionar idempotência ao load para Parquet e SQLite

### DIFF
--- a/src/load.py
+++ b/src/load.py
@@ -1,4 +1,5 @@
 import os
+import time
 import pandas as pd
 import sqlite3
 from sqlalchemy import create_engine
@@ -12,24 +13,39 @@ os.makedirs(GOLD_DIR, exist_ok=True)
 
 DB_URI = os.getenv("DB_URI")
 
-def aggregate_silver_files(run_id=None):
+def aggregate_silver_files(run_id=None, date_str=None):
     logger = get_logger(run_id=run_id, service="load")
     start = time.time()
 
-    files = [os.path.join(SILVER_DIR, f) for f in os.listdir(SILVER_DIR) if f.endswith(".parquet")]
+    if not date_str:
+        date_str = datetime.utcnow().strftime("%Y-%m-%d")
+
+    # Filtra arquivos Silver do dia específico
+    files = [os.path.join(SILVER_DIR, f) for f in os.listdir(SILVER_DIR) if f.endswith(".parquet") and date_str in f]
+    if not files:
+        logger.warning("no_silver_files", date=date_str)
+        return None
+
+    # Lê e concatena
     df_list = [pd.read_parquet(f) for f in files]
     df = pd.concat(df_list, ignore_index=True)
     df.drop_duplicates(subset=["date", "base_currency", "target_currency"], inplace=True)
 
-    gold_file = os.path.join(GOLD_DIR, f"{datetime.utcnow().strftime('%Y%m%d_%H%M%S')}.parquet")
+    # --- SALVA GOLD PARQUET (idempotente) ---
+    gold_file = os.path.join(GOLD_DIR, f"{date_str}.parquet")
     df.to_parquet(gold_file, engine="pyarrow", compression="snappy", index=False)
     logger.info("load_ok", arquivo=gold_file, count=len(df))
 
+    # Log de métricas
     elapsed = time.time() - start
     log_metrics(logger, "load", df.shape[0], elapsed)
 
+    # --- SALVA NO BANCO (idempotente) ---
     if DB_URI:
         engine = create_engine(DB_URI)
+        with engine.connect() as conn:
+            # Remove registros do mesmo dia antes de inserir
+            conn.execute("DELETE FROM exchange_rates WHERE date = :date", {"date": date_str})
         df.to_sql("exchange_rates", con=engine, if_exists="append", method="multi", index=False, chunksize=1000)
         logger.info("load_db_ok", table="exchange_rates", count=len(df))
 
@@ -39,19 +55,25 @@ def save_to_parquet(df: pd.DataFrame, outfile: str | Path):
     """Salva DataFrame em arquivo parquet"""
     df.to_parquet(outfile, index=False)
 
-def save_to_sqlite(df: pd.DataFrame, dbfile: str | Path, table_name: str):
-    """Salva DataFrame em banco SQLite"""
+def save_to_sqlite(df: pd.DataFrame, dbfile: str | Path, table_name: str, date_str=None):
+    """Salva DataFrame em banco SQLite de forma idempotente"""
     conn = sqlite3.connect(dbfile)
-    df.to_sql(table_name, conn, if_exists="replace", index=False)
+    cursor = conn.cursor()
+
+    if date_str:
+        # Remove registros do mesmo dia
+        cursor.execute(f"DELETE FROM {table_name} WHERE date = ?", (date_str,))
+        conn.commit()
+
+    df.to_sql(table_name, conn, if_exists="append", index=False)
     conn.close()
-    
+
 def main(date_str=None):
-    if not date_str:
-        date_str = datetime.utcnow().strftime("%Y-%m-%d")
+    gold_file = aggregate_silver_files(date_str=date_str)
+    if gold_file:
+        print(f"Gold file criado: {gold_file}")
+    else:
+        print(f"Nenhum arquivo Silver encontrado para {date_str}")
 
-    files = [f for f in os.listdir(SILVER_DIR) if f.endswith(".parquet") and date_str in f]
-    if not files:
-        print(f"Nenhum arquivo SILVER encontrado para {date_str}")
-        return
-
-    df_list = [pd.read_parquet(os.path.join(SILVER
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Evita duplicação de registros no Parquet e no SQLite quando o pipeline é rodado múltiplas vezes para o mesmo dia.
Mantém logs estruturados e métricas.